### PR TITLE
Adjusted invalid webpack configuration file

### DIFF
--- a/webpack.config.vendor.js
+++ b/webpack.config.vendor.js
@@ -1,7 +1,8 @@
+const path = require('path')
+
 const webpack = require('webpack')
 const CompressionPlugin = require('compression-webpack-plugin')
 const ManifestPlugin = require('webpack-manifest-plugin')
-
 module.exports = {
   entry: {
     vendor: [
@@ -22,7 +23,7 @@ module.exports = {
 
   output: {
     filename: '[name].[chunkhash].js',
-    path: 'dist/',
+    path: path.join(__dirname, 'dist'),
     library: '[name]_lib',
   },
 


### PR DESCRIPTION
yarn failed to build the webpack dev server app in a Docker container because [webpack.config.vendor.js](https://github.com/CheesecakeLabs/react-redux-boilerplate/blob/master/webpack.config.vendor.js#L25) doesn't validate an absolute path for `output`. This caused the Docker image to not get built properly.
```bash 
$ yarn build:vendor && yarn build:production
yarn build:vendor v0.24.6
$ NODE_ENV=production webpack --colors --config webpack.config.vendor.js --hide-modules
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.output.path: The provided value "dist/" is not an absolute path! 
error Command failed with exit code 1.
The command '/bin/sh -c yarn build' returned a non-zero code: 1
```

Appending the classic `path.join(__dirname, 'dist')` to the output path did the trick.