### PR TITLE
Fix button component props

### DIFF
--- a/src/components/button/index.js
+++ b/src/components/button/index.js
@@ -27,9 +27,9 @@ const Button = ({ type, onClick, children, theme, size }) => {
 }
 
 Button.propTypes = {
-  type: PropTypes.oneOf(Object.keys(ButtonType)),
-  theme: PropTypes.oneOf(Object.keys(ButtonTheme)),
-  size: PropTypes.oneOf(Object.keys(ButtonSize)),
+  type: PropTypes.oneOf(Object.values(ButtonType)),
+  theme: PropTypes.oneOf(Object.values(ButtonTheme)),
+  size: PropTypes.oneOf(Object.values(ButtonSize)),
   onClick: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
 }


### PR DESCRIPTION
I've noticed while using the Button component that the console was issuing a warning.
It was being caused by the props used in className being accessed by their key instead of their values.
Now it is working as intended