### PR TITLE
Use babel plugin transform-react-inline-elements only in prod

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
 {
-  "plugins": ["transform-react-inline-elements"],
   "presets": [
     [
       "es2015",
@@ -22,6 +21,9 @@
         "stage-0",
         "react"
       ]
+    },
+    "production": {
+      "plugins": ["transform-react-inline-elements"]
     }
   }
 }

--- a/src/views/home/index.js
+++ b/src/views/home/index.js
@@ -4,6 +4,8 @@ import Button, { ButtonType, ButtonTheme, ButtonSize } from '_components//button
 
 import styles from './styles.css'
 
+const noop = () => {}
+
 class Home extends PureComponent {
   state = {
     counter: 0,
@@ -49,13 +51,17 @@ class Home extends PureComponent {
         <br />
         <div className={styles.grid}>
           <div>
-            <Button>Default</Button>
+            <Button onClick={noop}>Default</Button>
           </div>
           <div>
-            <Button size={ButtonSize.SMALL}>Small</Button>
+            <Button onClick={noop} size={ButtonSize.SMALL}>
+              Small
+            </Button>
           </div>
           <div>
-            <Button size={ButtonSize.LARGE}>Larger</Button>
+            <Button onClick={noop} size={ButtonSize.LARGE}>
+              Larger
+            </Button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Because if you run this transform in dev you'll lose props validations